### PR TITLE
Fixed owners being hardcoded to 2 in bot.py, send_exception(), edited .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ saves
 auth.json
 log.txt
 collections2.py
+misc/help.json
+misc/index.html

--- a/bot.py
+++ b/bot.py
@@ -4308,8 +4308,9 @@ For any further questions or issues, read the documentation on <a href="{self.gi
         discord.http.HTTPClient.request = lambda self, *args, **kwargs: request(self, *args, **kwargs)
 
     def send_exception(self, messageable, ex, reference=None):
-        it = iter(self.owners)
-        owners = self.get_user(next(it)).mention + ", " + self.get_user(next(it)).mention
+        owners_list = self.owners
+        owners = ', '.join([self.get_user(owner).mention for owner in owners_list])
+
         return self.send_as_embeds(
             messageable,
             description="\n".join(as_str(i) for i in ex.args),

--- a/bot.py
+++ b/bot.py
@@ -4310,7 +4310,6 @@ For any further questions or issues, read the documentation on <a href="{self.gi
     def send_exception(self, messageable, ex, reference=None):
         owners_list = self.owners
         owners = ', '.join([self.get_user(owner).mention for owner in owners_list])
-
         return self.send_as_embeds(
             messageable,
             description="\n".join(as_str(i) for i in ex.args),


### PR DESCRIPTION
* In the send_exception() function, Miza would raise an error if only one owner was given, and would show only two if more than two owners were given.
* Added misc/index.html, misc/help.json to .gitignore. because those files are created automatically when Miza starts.