### PR TITLE
Fixes a bug in CS_m2f and adds related commands

### DIFF
--- a/commands/MISC.py
+++ b/commands/MISC.py
@@ -191,7 +191,7 @@ class CS_mem2flag(Command):
             num = 1
         else:
             num = await bot.eval_math(" ".join(args[1:]))
-        return css_md("".join(address_to_flag(int(args[0]), num)))
+        return css_md("".join(address_to_flag(int(args[0], 16), num)))
 
 
 class CS_flag2mem(Command):
@@ -219,7 +219,7 @@ class CS_num2val(Command):
             length = 4
         else:
             length = await bot.eval_math(" ".join(args[1:]))
-        return css_md(str(num_to_tsc_value(int(args[0]), length)))
+        return css_md(str(num_to_tsc_value(int(args[0], 0), length)))
 
 
 class CS_val2num(Command):

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ pytz>=2020.5
 requests>=2.26.0
 rule34>=1.8.1
 sympy>=1.8
-tsc-utils>=0.2.1
+tsc-utils>=0.2.2
 youtube-dl>=2021.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,5 @@ pytz>=2020.5
 requests>=2.26.0
 rule34>=1.8.1
 sympy>=1.8
+tsc-utils>=0.2.1
 youtube-dl>=2021.6.6


### PR DESCRIPTION
this implements my tsc-utils package as commands in the misc category, and updates the existing cs_m2f command to use the package's implementation which is more complete.

![image](https://user-images.githubusercontent.com/2979303/147736650-1424ca84-3987-43c5-a691-24caa55f7ea4.png)
cs_m2f: adds bounds checking and accounts for signed-ness of chars

![image](https://user-images.githubusercontent.com/2979303/147736750-68c16daf-507d-4848-93f5-a653adb40769.png)
cs_f2m: inverse of m2f, more or less

![image](https://user-images.githubusercontent.com/2979303/147736786-cc0e4423-4442-451d-af8b-d261a572252f.png)
cs_n2v and cs_v2n: helper commands for converting to/from TSC values